### PR TITLE
Add iostream-style formatting in log package (DM-3926)

### DIFF
--- a/doc/mainpage.dox
+++ b/doc/mainpage.dox
@@ -38,6 +38,11 @@ The `boost::format` style interface:
     LOGF("myLogger", LOG_LVL_INFO, "Here is some information about %s." % subject);
 
 
+The `iostream` style interface:
+
+    subject = "important stuff";
+    LOGS("myLogger", LOG_LVL_INFO, "Here is some information about " << subject << ".");
+
 
 Using the default logger:
 
@@ -46,7 +51,7 @@ Using the default logger:
 
 A logger object may be retrieved and used to avoid the cost of excessive lookups:
 
-    LOG_LOGGER logger = LOG_GET("myLogger");
+    static LOG_LOGGER logger = LOG_GET("myLogger");
     LOG(logger, LOG_LVL_WARN, "Here is a warning sent using a logging object.");
 
 
@@ -104,7 +109,7 @@ In C++, the following varargs/printf style logging macros are available:
 - `LOG_ERROR(fmt...)` Log a message of level `LOG_LVL_ERROR` with format string '''`fmt`''' and corresponding comma-separated arguments to the default logger.
 - `LOG_FATAL(fmt...)` Log a message of level `LOG_LVL_FATAL` with format string '''`fmt`''' and corresponding comma-separated arguments to the default logger.
 
-In addition to the above macros, in C++, the following `boost::format` style logging macros are offered:
+In addition to the above macros, in C++, the following `boost::format` style logging macros are offered (use of these macros is now deprecated, please switch to LOGS series of macro):
 - `LOGF(loggername, level, fmt)` Log a message of level '''`level`''' with format string '''`fmt`''' and corresponding '''`%`''' separated arguments to the logger named '''`loggername`'''.
 - `LOGF_TRACE(fmt)` Log a message of level `LOG_LVL_TRACE` with format string '''`fmt`''' and corresponding '''`%`''' separated arguments to the default logger.
 - `LOGF_DEBUG(fmt)` Log a message of level `LOG_LVL_DEBUG` with format string '''`fmt`''' and corresponding '''`%`''' separated arguments to the default logger.
@@ -112,6 +117,15 @@ In addition to the above macros, in C++, the following `boost::format` style log
 - `LOGF_WARN(fmt)` Log a message of level `LOG_LVL_WARN` with format string '''`fmt`''' and corresponding '''`%`''' separated arguments to the default logger.
 - `LOGF_ERROR(fmt)` Log a message of level `LOG_LVL_ERROR` with format string '''`fmt`''' and corresponding '''`%`''' separated arguments to the default logger.
 - `LOGF_FATAL(fmt)` Log a message of level `LOG_LVL_FATAL` with format string '''`fmt`''' and corresponding '''`%`''' separated arguments to the default logger.
+
+Alternative set of macros allows one to use iostream-based formatting. In the macros below `expression` is any C++ expression which can appear on the right side of the stream insertion operator, e.g. `LOGS_DEBUG("coordinates: x=" << x << " y=" << y);`. Usual caveat regarding  commas inside macro arguments applies to `expression` argument:
+- `LOGS(loggername, level, expression)` Log a message of level '''`level`''' to the logger named '''`loggername`'''.
+- `LOGS_TRACE(expression)` Log a message of level `LOG_LVL_TRACE` to the default logger.
+- `LOGS_DEBUG(expression)` Log a message of level `LOG_LVL_DEBUG` to the default logger.
+- `LOGS_INFO(expression)` Log a message of level `LOG_LVL_INFO` to the default logger.
+- `LOGS_WARN(expression)` Log a message of level `LOG_LVL_WARN` to the default logger.
+- `LOGS_ERROR(expression)` Log a message of level `LOG_LVL_ERROR` to the default logger.
+- `LOGS_FATAL(expression)` Log a message of level `LOG_LVL_FATAL` to the default logger.
 
 In Python, the following logging functions are available in the `lsst.log` module. These functions take a variable number of arguments following a format string in the style of `printf()`. The use of `*args` is recommended over the use of the `%` operator so that formatting of log messages that do not meet the level threshold can be avoided.
 - `log(loggername, level, fmt, *args)` Log a message of level '''`level`''' with format string '''`fmt`''' and variable arguments '''`*args`''' to the logger named '''`loggername`'''.

--- a/include/lsst/log/Log.h
+++ b/include/lsst/log/Log.h
@@ -34,7 +34,7 @@
 
 
 // System headers
-#include <stack>
+#include <sstream>
 #include <stdarg.h>
 #include <string>
 #include <vector>
@@ -218,6 +218,8 @@
   * @def LOGF(logger, level, message)
   * Log a message using a boost::format style interface.
   *
+  * @deprecated Use LOGS family of macros instead.
+  *
   * @param logger   Either name of logger or log4cxx logger object.
   * @param level    Logging level associated with message.
   * @param message  A boost::format compatible format string followed by
@@ -236,6 +238,8 @@
   * Log a trace-level message to the default logger using a boost::format
   * style interface.
   *
+  * @deprecated Use LOGS family of macros instead.
+  *
   * @param message  A boost::format compatible format string followed by
   *                 zero, one, or more arguments separated by `%`.
   */
@@ -251,6 +255,8 @@
   * @def LOGF_DEBUG(message)
   * Log a debug-level message to the default logger using a boost::format
   * style interface.
+  *
+  * @deprecated Use LOGS family of macros instead.
   *
   * @param message  A boost::format compatible format string followed by
   *                 zero, one, or more arguments separated by `%`.
@@ -268,6 +274,8 @@
   * Log a info-level message to the default logger using a boost::format
   * style interface.
   *
+  * @deprecated Use LOGS family of macros instead.
+  *
   * @param message  A boost::format compatible format string followed by
   *                 zero, one, or more arguments separated by `%`.
   */
@@ -283,6 +291,8 @@
   * @def LOGF_WARN(message)
   * Log a warn-level message to the default logger using a boost::format
   * style interface.
+  *
+  * @deprecated Use LOGS family of macros instead.
   *
   * @param message  A boost::format compatible format string followed by
   *                 zero, one, or more arguments separated by `%`.
@@ -300,6 +310,8 @@
   * Log a error-level message to the default logger using a boost::format
   * style interface.
   *
+  * @deprecated Use LOGS family of macros instead.
+  *
   * @param message  A boost::format compatible format string followed by
   *                 zero, one, or more arguments separated by `%`.
   */
@@ -315,6 +327,8 @@
   * @def LOGF_FATAL(message)
   * Log a fatal-level message to the default logger using a boost::format
   * style interface.
+  *
+  * @deprecated Use LOGS family of macros instead.
   *
   * @param message  A boost::format compatible format string followed by
   *                 zero, one, or more arguments separated by `%`.
@@ -430,6 +444,149 @@
         lsst::log::Log::log(lsst::log::Log::defaultLogger, \
             log4cxx::Level::getFatal(), __BASE_FILE__, __PRETTY_FUNCTION__, \
             __LINE__, message); } \
+    } while (false)
+
+/**
+  * @def LOGS(logger, level, message)
+  * Log a message using an iostream-based interface.
+  *
+  * Message is any expression which can appear on the right side of the
+  * stream insertion operator, e.g.
+  * `LOGS("logger", LOG_LVL_DEBUG, "coordinates: x=" << x << " y=" << y);`.
+  * Usual caveat regarding commas inside macro arguments applies to
+  * message argument.
+  *
+  * @param logger   Either name of logger or log4cxx logger object.
+  * @param level    Logging level associated with message.
+  * @param message  Message to be logged.
+  */
+#define LOGS(logger, level, message) \
+    do { if (lsst::log::Log::isEnabledFor(logger, level)) { \
+        std::ostringstream stream_; \
+        stream_ << message; \
+        lsst::log::Log::getLogger(logger)->forcedLog( \
+            log4cxx::Level::toLevel(level), stream_.str(), \
+            LOG4CXX_LOCATION); } \
+    } while (false)
+
+/**
+  * @def LOGS_TRACE(message)
+  * Log a trace-level message to the default logger using an iostream-based interface.
+  *
+  * Message is any expression which can appear on the right side of the
+  * stream insertion operator, e.g.
+  * `LOGS_TRACE("coordinates: x=" << x << " y=" << y);`. Usual caveat regarding
+  * commas inside macro arguments applies to message argument.
+  *
+  * @param message Message to be logged.
+  */
+#define LOGS_TRACE(message) \
+    do { if (LOG4CXX_UNLIKELY(lsst::log::Log::defaultLogger->isTraceEnabled())) { \
+        std::ostringstream stream_; \
+        stream_ << message; \
+        lsst::log::Log::defaultLogger->forcedLog( \
+            log4cxx::Level::getTrace(), stream_.str(), \
+            LOG4CXX_LOCATION); } \
+    } while (false)
+
+/**
+  * @def LOGS_DEBUG(message)
+  * Log a debug-level message to the default logger using an iostream-based interface.
+  *
+  * Message is any expression which can appear on the right side of the
+  * stream insertion operator, e.g.
+  * `LOGS_DEBUG("coordinates: x=" << x << " y=" << y);`. Usual caveat regarding
+  * commas inside macro arguments applies to message argument.
+  *
+  * @param message Message to be logged.
+  */
+#define LOGS_DEBUG(message) \
+    do { if (LOG4CXX_UNLIKELY(lsst::log::Log::defaultLogger->isDebugEnabled())) { \
+        std::ostringstream stream_; \
+        stream_ << message; \
+        lsst::log::Log::defaultLogger->forcedLog( \
+            log4cxx::Level::getDebug(), stream_.str(), \
+            LOG4CXX_LOCATION); } \
+    } while (false)
+
+/**
+  * @def LOGS_INFO(message)
+  * Log a info-level message to the default logger using an iostream-based interface.
+  *
+  * Message is any expression which can appear on the right side of the
+  * stream insertion operator, e.g.
+  * `LOGS_INFO("coordinates: x=" << x << " y=" << y);`. Usual caveat regarding
+  * commas inside macro arguments applies to message argument.
+  *
+  * @param message Message to be logged.
+  */
+#define LOGS_INFO(message) \
+    do { if (lsst::log::Log::defaultLogger->isInfoEnabled()) { \
+        std::ostringstream stream_; \
+        stream_ << message; \
+        lsst::log::Log::defaultLogger->forcedLog( \
+            log4cxx::Level::getInfo(), stream_.str(), \
+            LOG4CXX_LOCATION); } \
+    } while (false)
+
+/**
+  * @def LOGS_WARN(message)
+  * Log a warning-level message to the default logger using an iostream-based interface.
+  *
+  * Message is any expression which can appear on the right side of the
+  * stream insertion operator, e.g.
+  * `LOGS_WARN("coordinates: x=" << x << " y=" << y);`. Usual caveat regarding
+  * commas inside macro arguments applies to message argument.
+  *
+  * @param message Message to be logged.
+  */
+#define LOGS_WARN(message) \
+    do { if (lsst::log::Log::defaultLogger->isWarnEnabled()) { \
+        std::ostringstream stream_; \
+        stream_ << message; \
+        lsst::log::Log::defaultLogger->forcedLog( \
+            log4cxx::Level::getWarn(), stream_.str(), \
+            LOG4CXX_LOCATION); } \
+    } while (false)
+
+/**
+  * @def LOGS_ERROR(message)
+  * Log a error-level message to the default logger using an iostream-based interface.
+  *
+  * Message is any expression which can appear on the right side of the
+  * stream insertion operator, e.g.
+  * `LOGS_ERROR("coordinates: x=" << x << " y=" << y);`. Usual caveat regarding
+  * commas inside macro arguments applies to message argument.
+  *
+  * @param message Message to be logged.
+  */
+#define LOGS_ERROR(message) \
+    do { if (lsst::log::Log::defaultLogger->isErrorEnabled()) { \
+        std::ostringstream stream_; \
+        stream_ << message; \
+        lsst::log::Log::defaultLogger->forcedLog( \
+            log4cxx::Level::getError(), stream_.str(), \
+            LOG4CXX_LOCATION); } \
+    } while (false)
+
+/**
+  * @def LOGS_FATAL(message)
+  * Log a fatal-level message to the default logger using an iostream-based interface.
+  *
+  * Message is any expression which can appear on the right side of the
+  * stream insertion operator, e.g.
+  * `LOGS_FATAL("coordinates: x=" << x << " y=" << y);`. Usual caveat regarding
+  * commas inside macro arguments applies to message argument.
+  *
+  * @param message Message to be logged.
+  */
+#define LOGS_FATAL(message) \
+    do { if (lsst::log::Log::defaultLogger->isFatalEnabled()) { \
+        std::ostringstream stream_; \
+        stream_ << message; \
+        lsst::log::Log::defaultLogger->forcedLog( \
+            log4cxx::Level::getFatal(), stream_.str(), \
+            LOG4CXX_LOCATION); } \
     } while (false)
 
 #define LOG_LVL_TRACE static_cast<int>(log4cxx::Level::TRACE_INT)


### PR DESCRIPTION
Added a series of LOGS macros which are going to replace LOGF macros
using the iostream-style formatting instead of boost::format. LOGF
macros are deprecated but kept until everyone (qserv) migrates their
code. Documentation and unit tests are updated.