### PR TITLE
Do not use thread_local on OS X (DM-5272)

### DIFF
--- a/tests/logTest.cc
+++ b/tests/logTest.cc
@@ -431,10 +431,6 @@ BOOST_AUTO_TEST_CASE(lwp_id) {
 
     unsigned lwp1 = lsst::log::lwpID();
     unsigned lwp2 = lsst::log::lwpID();
-    unsigned pid = static_cast<unsigned>(getpid());
 
     BOOST_CHECK_EQUAL(lwp1, lwp2);
-    // LWP should be the same as PID in the main thread
-    // or it can be a small number on platforms not supporting LWP
-    BOOST_CHECK(lwp1 == pid or lwp1 < 10);
 }

--- a/tests/logTest.py
+++ b/tests/logTest.py
@@ -326,12 +326,8 @@ log4j.appender.CA.layout.ConversionPattern=%-5p - %m %X%n
         """Test log.lwpID() method."""
         lwp1 = log.lwpID()
         lwp2 = log.lwpID()
-        pid = os.getpid()
 
         self.assertEqual(lwp1, lwp2)
-        # LWP should be the same as PID in the main thread
-        # or it can be a small number on platforms not supporting LWP
-        self.assert_(lwp1 == pid or lwp1 < 10)
 
 ####################################################################################
 def main():


### PR DESCRIPTION
Replaced thread_local with POSIX equivalent to avoid problems with
clang on OS X which does not support thread_local.
