### PR TITLE
DM-7188: Enable unicode strings in swig interface on Python 2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -9,9 +9,12 @@ config.log
 *_wrap.cc
 *Lib.py
 /doc/html
+/doc/xml
 /doc/*.tag
 /doc/*.inc
 /doc/doxygen.conf
+/lib/liblog.*
+/tests/.cache
 /tests/.tests
 /tests/cppTest
 /tests/logTest

--- a/examples/mp.py
+++ b/examples/mp.py
@@ -3,6 +3,7 @@
 import lsst.log as log
 import multiprocessing as mp
 
+
 def main():
     # Set component to "main" (from "root")
     with log.LogContext("main"):
@@ -15,6 +16,7 @@ def main():
         b()
         log.info("Leaving main")
 
+
 def a(visit):
     # Set subcomponent to "a" (sets component to "main.a")
     with log.LogContext("a"):
@@ -26,6 +28,7 @@ def a(visit):
         log.debug("Debug message in a")
         b()
         log.info("Leaving a")
+
 
 def b():
     # Set subcomponent to "b" (sets component to "main.a.b" or "main.b")

--- a/python/lsst/log/log.py
+++ b/python/lsst/log/log.py
@@ -35,62 +35,82 @@ FATAL = Log.FATAL
 
 # Export static functions from Log class to module namespace
 
+
 def configure(*args):
     Log.configure(*args)
+
 
 def configure_prop(properties):
     Log.configure_prop(properties)
 
+
 def getDefaultLoggerName():
     return Log.getDefaultLoggerName()
+
 
 def pushContext(name):
     Log.pushContext(name)
 
+
 def popContext():
     Log.popContext()
+
 
 def MDC(key, value):
     Log.MDC(key, str(value))
 
+
 def MDCRemove(key):
     Log.MDCRemove(key)
+
 
 def MDCRegisterInit(func):
     Log.MDCRegisterInit(func)
 
+
 def setLevel(loggername, level):
     Log.getLogger(loggername).setLevel(level)
+
 
 def getLevel(loggername):
     Log.getLogger(loggername).getLevel()
 
+
 def isEnabledFor(logger, level):
     Log.getLogger(logger).isEnabledFor(level)
+
 
 def log(loggername, level, fmt, *args, **kwargs):
     Log.getLogger(loggername)._log(level, fmt, *args)
 
+
 def trace(fmt, *args):
     Log.getDefaultLogger()._log(TRACE, fmt, *args)
+
 
 def debug(fmt, *args):
     Log.getDefaultLogger()._log(DEBUG, fmt, *args)
 
+
 def info(fmt, *args):
     Log.getDefaultLogger()._log(INFO, fmt, *args)
+
 
 def warn(fmt, *args):
     Log.getDefaultLogger()._log(WARN, fmt, *args)
 
+
 def error(fmt, *args):
     Log.getDefaultLogger()._log(ERROR, fmt, *args)
+
 
 def fatal(fmt, *args):
     Log.getDefaultLogger()._log(FATAL, fmt, *args)
 
+
 def lwpID():
     return Log.lwpID
+
 
 class LogContext(object):
     """Context manager for logging."""
@@ -128,6 +148,7 @@ class LogContext(object):
 
     def isEnabledFor(self, level):
         return Log.getDefaultLogger().isEnabledFor(level)
+
 
 class LogHandler(logging.Handler):
     """Handler for Python logging module that emits to LSST logging."""

--- a/python/lsst/log/logLib.i
+++ b/python/lsst/log/logLib.i
@@ -23,7 +23,7 @@ Access to the classes from the log library
 %{
 // Wrapper for Python callable object to make sure that we have GIL
 // when we call Python. Note that we are leaking Python callable,
-// as C++ callables may be (and actually are in our particular case) 
+// as C++ callables may be (and actually are in our particular case)
 // outliving Python interpreter and attempt to delete Python object
 // will result in crash.
 class callable_wrapper {

--- a/python/lsst/log/logLib.i
+++ b/python/lsst/log/logLib.i
@@ -11,6 +11,11 @@ Access to the classes from the log library
 %naturalvar;
 %include "std_string.i"
 
+// Allow Python2 to accept unicode strings
+%begin %{
+#define SWIG_PYTHON_2_UNICODE
+%}
+
 %{
 #include "lsst/log/Log.h"
 %}

--- a/tests/logTest.cc
+++ b/tests/logTest.cc
@@ -1,7 +1,7 @@
-/* 
+/*
  * LSST Data Management System
  * Copyright 2014 LSST Corporation.
- * 
+ *
  * This product includes software developed by the
  * LSST Project (http://www.lsst.org/).
  *
@@ -9,17 +9,17 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation, either version 3 of the License, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
  * GNU General Public License for more details.
- * 
- * You should have received a copy of the LSST License Statement and 
- * the GNU General Public License along with this program.  If not, 
+ *
+ * You should have received a copy of the LSST License Statement and
+ * the GNU General Public License along with this program.  If not,
  * see <http://www.lsstcorp.org/LegalNotices/>.
  */
- 
+
 // System headers
 #include <cstdio>
 #include <fstream>

--- a/tests/logTest.py
+++ b/tests/logTest.py
@@ -27,10 +27,10 @@ This tests the logging system in a variety of ways.
 import lsst.log as log
 import os
 import shutil
-import sys
 import tempfile
 import threading
 import unittest
+
 
 class TestLog(unittest.TestCase):
 
@@ -213,8 +213,7 @@ INFO  component  testPattern (logTest.py:{0[6]}) logTest.py({0[6]}) - This is IN
 DEBUG component  testPattern (logTest.py:{0[7]}) logTest.py({0[7]}) - This is DEBUG 4 - {{{{y,foo}}}}
 INFO  root  testPattern (logTest.py:{0[8]}) logTest.py({0[8]}) - This is INFO 5 - {{{{y,foo}}}}
 DEBUG root  testPattern (logTest.py:{0[9]}) logTest.py({0[9]}) - This is DEBUG 5 - {{{{y,foo}}}}
-""".format([x + 178 for x in (0, 1, 8, 9, 14, 15, 18, 19, 22, 23)], __name__))
-
+""".format([x + 177 for x in (0, 1, 8, 9, 14, 15, 18, 19, 22, 23)], __name__))
 
     def testMDCPutPid(self):
         """
@@ -244,7 +243,7 @@ log4j.appender.CA.layout.ConversionPattern=%-5p PID:%X{{PID}} %c %C %M (%F:%L) %
 
             with TestLog.StdoutCapture(self.outputFilename):
                 log.info(msg)
-                line = 247
+                line = 245
         finally:
             log.MDCRemove("PID")
 
@@ -310,7 +309,8 @@ log4j.appender.CA.layout=PatternLayout
 log4j.appender.CA.layout.ConversionPattern=%-5p - %m %X%n
 """)
 
-            fun = lambda : log.MDC("MDC_INIT", "OK")
+            def fun():
+                log.MDC("MDC_INIT", "OK")
             log.MDCRegisterInit(fun)
 
             log.info("main thread")

--- a/tests/logTest.py
+++ b/tests/logTest.py
@@ -75,9 +75,10 @@ class TestLog(unittest.TestCase):
     def check(self, reference):
         """Compare the log file with the provided reference text."""
         with open(self.outputFilename, 'r') as f:
-            lines = [l.split(']')[-1] for l in f.readlines()]
-            reflines = [l + "\n" for l in reference.split("\n") if l != ""]
-            map(self.assertEqual, lines, reflines)
+            lines = [l.split(']')[-1].rstrip("\n") for l in f.readlines()]
+            reflines = [l for l in reference.split("\n") if l != ""]
+            self.maxDiff = None
+            self.assertListEqual(lines, reflines)
 
 
 ###############################################################################

--- a/tests/logTest.py
+++ b/tests/logTest.py
@@ -94,6 +94,7 @@ class TestLog(unittest.TestCase):
         with TestLog.StdoutCapture(self.outputFilename):
             log.configure()
             log.log(log.getDefaultLoggerName(), log.INFO, "This is INFO")
+            log.info(u"This is unicode INFO")
             log.trace("This is TRACE")
             log.debug("This is DEBUG")
             log.warn("This is WARN")
@@ -102,6 +103,7 @@ class TestLog(unittest.TestCase):
             log.info("Format %d %g %s", 3, 2.71828, "foo")
         self.check("""
  INFO root null - This is INFO
+ INFO root null - This is unicode INFO
  DEBUG root null - This is DEBUG
  WARN root null - This is WARN
  ERROR root null - This is ERROR
@@ -210,7 +212,7 @@ INFO  component  testPattern (logTest.py:{0[6]}) logTest.py({0[6]}) - This is IN
 DEBUG component  testPattern (logTest.py:{0[7]}) logTest.py({0[7]}) - This is DEBUG 4 - {{{{y,foo}}}}
 INFO  root  testPattern (logTest.py:{0[8]}) logTest.py({0[8]}) - This is INFO 5 - {{{{y,foo}}}}
 DEBUG root  testPattern (logTest.py:{0[9]}) logTest.py({0[9]}) - This is DEBUG 5 - {{{{y,foo}}}}
-""".format([x + 174 for x in (0, 1, 8, 9, 14, 15, 18, 19, 22, 23)], __name__))
+""".format([x + 178 for x in (0, 1, 8, 9, 14, 15, 18, 19, 22, 23)], __name__))
 
 
     def testMDCPutPid(self):
@@ -241,7 +243,7 @@ log4j.appender.CA.layout.ConversionPattern=%-5p PID:%X{{PID}} %c %C %M (%F:%L) %
 
             with TestLog.StdoutCapture(self.outputFilename):
                 log.info(msg)
-                line = 243
+                line = 247
         finally:
             log.MDCRemove("PID")
 


### PR DESCRIPTION
Also some minor code cleanups.