### PR TITLE
DM-7754: Ensure initialization is done before first use

### DIFF
--- a/include/lsst/log/Log.h
+++ b/include/lsst/log/Log.h
@@ -798,7 +798,12 @@ private:
      */
     static log4cxx::LoggerPtr& _defaultLogger();
 
-    Log(log4cxx::LoggerPtr const& logger) : _logger(logger) { }
+    /**
+     *  Construct a Log using a LOG4CXX logger.
+     *
+     *  The default constructor is called to ensure the default logger is initialized and LOG4CXX is configured.
+     */
+    Log(log4cxx::LoggerPtr const& logger) : Log() { _logger = logger; }
 
     log4cxx::LoggerPtr _logger;
 };


### PR DESCRIPTION
The basic configuration is ensured through the first call to the
default logger. Currently this may be bypassed if getLogger('nonRoot')
is called before a default logger is set.  Fix this by delegating
the private constructor to the default constructor.