### PR TITLE
Remove static Log::log() and Log::logMsg() methods (DM-6978).

### DIFF
--- a/include/lsst/log/Log.h
+++ b/include/lsst/log/Log.h
@@ -778,15 +778,9 @@ public:
     static void MDCRemove(std::string const& key);
     static int MDCRegisterInit(std::function<void()> function);
 
-    static void log(Log logger, log4cxx::LevelPtr level,
-                    log4cxx::spi::LocationInfo const& location,
-                    char const* fmt, ...);
     void log(log4cxx::LevelPtr level,
              log4cxx::spi::LocationInfo const& location,
              char const* fmt, ...);
-    static void logMsg(Log logger, log4cxx::LevelPtr level,
-                       log4cxx::spi::LocationInfo const& location,
-                       std::string const& msg);
     void logMsg(log4cxx::LevelPtr level,
                 log4cxx::spi::LocationInfo const& location,
                 std::string const& msg);

--- a/src/Log.cc
+++ b/src/Log.cc
@@ -391,23 +391,7 @@ void Log::log(log4cxx::LevelPtr level,     ///< message level
     logMsg(level, location, msg);
 }
 
-/** Method used by LOG_INFO and similar macros to process a log message
-  * with variable arguments along with associated metadata.
-  */
-void Log::log(Log logger,   ///< the logger
-              log4cxx::LevelPtr level,     ///< message level
-              log4cxx::spi::LocationInfo const& location,  ///< message origin location
-              char const* fmt,             ///< message format string
-              ...                          ///< message arguments
-             ) {
-    va_list args;
-    va_start(args, fmt);
-    char msg[MAX_LOG_MSG_LEN];
-    vsnprintf(msg, MAX_LOG_MSG_LEN, fmt, args);
-    logger.logMsg(level, location, msg);
-}
-
-/** Method used by LOGS_INFO and similar macros to process a log message..
+/** Method used by LOGS_INFO and similar macros to process a log message.
   */
 void Log::logMsg(log4cxx::LevelPtr level,     ///< message level
                  log4cxx::spi::LocationInfo const& location,  ///< message origin location
@@ -432,16 +416,6 @@ void Log::logMsg(log4cxx::LevelPtr level,     ///< message level
 
     // forward everything to logger
     _logger->forcedLog(level, msg, location);
-}
-
-/** Method used by LOGS_INFO and similar macros to process a log message..
-  */
-void Log::logMsg(Log logger, ///< the logger
-                 log4cxx::LevelPtr level,     ///< message level
-                 log4cxx::spi::LocationInfo const& location,  ///< message origin location
-                 std::string const& msg       ///< message string
-                 ) {
-    logger.logMsg(level, location, msg);
 }
 
 unsigned lwpID() {


### PR DESCRIPTION
QServ was the only place whch used static logMsg(), this ticket changes
qserv code to use non-static version of that method so we can also
remove static methods completely.