### PR TITLE
DM-10608: Log: avoid use of inspect.stack()

### DIFF
--- a/python/lsst/log/log/logContinued.py
+++ b/python/lsst/log/log/logContinued.py
@@ -80,7 +80,7 @@ class Log:
             frame = inspect.currentframe().f_back    # calling method
             frame = frame.f_back    # original log location
             filename = os.path.split(frame.f_code.co_filename)[1]
-            funcname = inspect.stack()[2][3]
+            funcname = frame.f_code.co_name
             if use_format:
                 msg = fmt.format(*args, **kwargs) if args or kwargs else fmt
             else:


### PR DESCRIPTION
inspect.stack() will go and read the source files, which introduces I/O
that we'd like to avoid in order to minimise overheads. We don't need
to read the source to get the function name, which can be grabbed from
the frame.