### PR TITLE
log depends on utils python not utils C++

### DIFF
--- a/ups/log.cfg
+++ b/ups/log.cfg
@@ -9,7 +9,7 @@ import lsst.sconsUtils
 # table files.
 dependencies = {
     "required": ["log4cxx"],
-    "buildRequired": ["boost_test", "python", "pybind11", "utils"],
+    "buildRequired": ["boost_test", "python", "pybind11"],
     "optional": [],
     "buildOptional": [],
 }


### PR DESCRIPTION
We should not be linking against `libutils`.