### PR TITLE
DM-17651: Allow lsst.log to forward to Python logging

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -21,3 +21,5 @@ version.py
 .coverage
 *.gcda
 *.gcno
+.pytest_cache
+pytest_session.txt

--- a/python/lsst/log/log/logContinued.py
+++ b/python/lsst/log/log/logContinued.py
@@ -80,6 +80,9 @@ class Log:
     def warn(self, fmt, *args):
         self._log(Log.WARN, False, fmt, *args)
 
+    def warning(self, fmt, *args):
+        self.warn(fmt, *args)
+
     def error(self, fmt, *args):
         self._log(Log.ERROR, False, fmt, *args)
 
@@ -189,6 +192,10 @@ def info(fmt, *args):
 
 def warn(fmt, *args):
     Log.getDefaultLogger()._log(WARN, False, fmt, *args)
+
+
+def warning(fmt, *args):
+    warn(fmt, *args)
 
 
 def error(fmt, *args):

--- a/python/lsst/log/log/logContinued.py
+++ b/python/lsst/log/log/logContinued.py
@@ -347,7 +347,7 @@ class LogHandler(logging.Handler):
             # If something else should happen then the caller should add a
             # second Handler.
             stream = logging.StreamHandler()
-            stream.setFormatter(logging.Formatter(fmt="%(name)s %(levelname)s: %(message)s"))
+            stream.setFormatter(logging.Formatter(fmt="%(name)s %(levelname)s (fallback): %(message)s"))
             stream.handle(record)
             return
 

--- a/python/lsst/log/log/logContinued.py
+++ b/python/lsst/log/log/logContinued.py
@@ -277,6 +277,19 @@ class LogContext(object):
         return Log.getDefaultLogger().isEnabledFor(level)
 
 
+class UsePythonLogging:
+    """Context manager to enable Python log forwarding temporarily."""
+
+    def __init__(self):
+        self.current = Log.UsePythonLogging
+
+    def __enter__(self):
+        Log.usePythonLogging()
+
+    def __exit__(self, exc_type, exc_value, traceback):
+        Log.UsePythonLogging = self.current
+
+
 class LogHandler(logging.Handler):
     """Handler for Python logging module that emits to LSST logging.
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -102,7 +102,7 @@ class TestLog(unittest.TestCase):
             log.warn("This is WARN")
             log.error("This is ERROR")
             log.fatal("This is FATAL")
-            log.warn("Format %d %g %s", 3, 2.71828, "foo")
+            log.warning("Format %d %g %s", 3, 2.71828, "foo")
         self.check("""
 root INFO: This is INFO
 root INFO: This is unicode INFO
@@ -609,7 +609,7 @@ INFO message: lsst.log root logger, PythonLogging""")
 
         # Without forwarding we only get python logger messages captured
         with self.assertLogs(level="WARNING") as cm:
-            log.warn("lsst.log: not forwarded")
+            log.warning("lsst.log: not forwarded")
             logging.warning("Python logging: captured")
         self.assertEqual(len(cm.output), 1)
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -489,5 +489,28 @@ root DEBUG: DEBUG with %s
 """)
 
 
+class TestPythonLogForwarding(unittest.TestCase):
+
+    def setUp(self):
+        log.usePythonLogging()
+
+    def tearDown(self):
+        log.doNotUsePythonLogging()
+
+    def testForwardToPython(self):
+        with self.assertLogs(level="WARNING"):
+            log.warn("This is a warning meant for python logging")
+
+    def testLogLoop(self):
+        # Test for log loop
+        import logging
+        lgr = logging.getLogger()
+        lgr.setLevel(logging.INFO)
+        lgr.addHandler(log.LogHandler())
+        with self.assertRaises(RuntimeError):
+            lgr.info("This will fail")
+        logging.shutdown()
+
+
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -311,17 +311,22 @@ DEBUG - This is DEBUG
     def testPythonLogging(self):
         """Test logging through the Python logging interface."""
         with TestLog.StdoutCapture(self.outputFilename):
-            import logging
             lgr = logging.getLogger()
             lgr.setLevel(logging.INFO)
-            lgr.addHandler(log.LogHandler())
             log.configure()
-            lgr.info("This is INFO")
-            lgr.debug("This is DEBUG")
-            lgr.warning("This is %s", "WARNING")
-            # message can be arbitrary Python object
-            lgr.info(((1, 2), (3, 4)))
-            lgr.info({1: 2})
+            with self.assertLogs(level="INFO") as cm:
+                # Force the lsst.log handler to be applied as well as the
+                # unittest log handler
+                lgr.addHandler(log.LogHandler())
+                lgr.info("This is INFO")
+                lgr.debug("This is DEBUG")
+                lgr.warning("This is %s", "WARNING")
+                # message can be arbitrary Python object
+                lgr.info(((1, 2), (3, 4)))
+                lgr.info({1: 2})
+
+            # Confirm that Python logging also worked
+            self.assertEqual(len(cm.output), 4, f"Got output: {cm.output}")
             logging.shutdown()
 
         self.check("""

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -602,6 +602,27 @@ INFO message: lsst.log root logger, PythonLogging""")
 
         logging.shutdown()
 
+    def testForwardToPythonContextManager(self):
+        """Test that `lsst.log` log messages can be forwarded to `logging`
+        using context manager"""
+        log.configure()
+
+        # Without forwarding we only get python logger messages captured
+        with self.assertLogs(level="WARNING") as cm:
+            log.warn("lsst.log: not forwarded")
+            logging.warning("Python logging: captured")
+        self.assertEqual(len(cm.output), 1)
+
+        # Temporarily turn on forwarding
+        with log.UsePythonLogging():
+            with self.assertLogs(level="WARNING") as cm:
+                log.warn("lsst.log: forwarded")
+                logging.warning("Python logging: also captured")
+            self.assertEqual(len(cm.output), 2)
+
+        # Verify that forwarding is disabled
+        self.assertFalse(log.Log.UsePythonLogging)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
This only deals with the python messages.  C++ log messages will do what they always do.  This is implemented as a big class property on `lsst.log.Log`. The idea is that a test can turn this on in `setUp`, check that a log message was created, and then turn it off in `tearDown`.