### PR TITLE
DM-17741: Factor out code to convert between logging levels

### DIFF
--- a/python/lsst/log/log/logContinued.py
+++ b/python/lsst/log/log/logContinued.py
@@ -297,11 +297,23 @@ class UsePythonLogging:
 
 
 class LevelTranslator:
-    """Helper class to translate levels between lsst.log and Python logging.
+    """Helper class to translate levels between ``lsst.log`` and Python
+    `logging`.
     """
     @staticmethod
     def lsstLog2logging(level):
-        """Translates from lsst.log/log4cxx levels to logging module levels.
+        """Translates from lsst.log/log4cxx levels to `logging` module levels.
+
+        Parameters
+        ----------
+        level : `int`
+            Logging level number used by `lsst.log`, typically one of the
+            constants defined in this module (`DEBUG`, `INFO`, etc.)
+
+        Returns
+        -------
+        level : `int`
+            Correspoding logging level number for Python `logging` module.
         """
         # Python logging levels are same as lsst.log divided by 1000,
         # logging does not have TRACE level by default but it is OK to use
@@ -310,8 +322,20 @@ class LevelTranslator:
 
     @staticmethod
     def logging2lsstLog(level):
-        """Translates from standard python logging module levels
-        to standard lsst.log/log4cxx levels.
+        """Translates from standard python `logging` module levels to
+        lsst.log/log4cxx levels.
+
+        Parameters
+        ----------
+        level : `int`
+            Logging level number used by Python `logging`, typically one of
+            the constants defined by `logging` module (`logging.DEBUG`,
+            `logging.INFO`, etc.)
+
+        Returns
+        -------
+        level : `int`
+            Correspoding logging level number for `lsst.log` module.
         """
         return level*1000
 

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -623,6 +623,21 @@ INFO message: lsst.log root logger, PythonLogging""")
         # Verify that forwarding is disabled
         self.assertFalse(log.Log.UsePythonLogging)
 
+    def testLevelTranslator(self):
+        """Test LevelTranslator class
+        """
+        # correspondence between levels, logging has no TRACE but we accept
+        # small integer in its place
+        levelMap = ((log.TRACE, 5),
+                    (log.DEBUG, logging.DEBUG),
+                    (log.INFO, logging.INFO),
+                    (log.WARN, logging.WARNING),
+                    (log.ERROR, logging.ERROR),
+                    (log.FATAL, logging.FATAL))
+        for logLevel, loggingLevel in levelMap:
+            self.assertEqual(log.LevelTranslator.lsstLog2logging(logLevel), loggingLevel)
+            self.assertEqual(log.LevelTranslator.logging2lsstLog(loggingLevel), logLevel)
+
 
 if __name__ == "__main__":
     unittest.main()


### PR DESCRIPTION
Two methods for two-way translation are moved into a special new
"namespace" class to keep interfaces clean.