### PR TITLE
DM-17874: Remove ContextLog class and related code

### DIFF
--- a/doc/mainpage.dox
+++ b/doc/mainpage.dox
@@ -13,7 +13,6 @@
 - Optionally include and format metadata including date, time, level, logger name, thread, function, source file, line number.
 - Optionally add arbitrary thread-scoped metadata (e.g. key/value pairs) to logging context programmatically.
 - Hierarchical, named loggers with independent configurations (e.g. levels, output channels, metadata, formatting).
-- Dynamic hierarchical logging contexts via `push()` and `pop()` functions.
 - Logging context objects automatically handle pushing/popping of names onto/off of global context in either C++ or Python.
 - Offers alternative interface that is compatible with standard Python logging module.
 - Configure loggers via single standard log4cxx XML or standard log4j Java properties file.
@@ -70,11 +69,11 @@ avoid filtering on Python side by setting logging level to DEBUG for root
 logger and instead configure log4cxx with proper logging level.
 
 
-Alternatively, get a logger through lsst.log.Log:
+Alternatively, get a logger through lsst.log:
 
-    lgr = lsst.log.Log.getLogger("myLogger")
+    lgr = lsst.log.getLogger("myLogger")
     lgr.setLevel(lgr.DEBUG)
-    lgr.info("This is an info statement via %s", "lsst.log.Log interface.")
+    lgr.info("This is an info statement via %s", "lsst.log interface.")
 
 \section exampleOutput Example output
 
@@ -290,57 +289,6 @@ In Python, the `lsst.log` module includes the following functions and variables:
 - `FATAL` Fatal logging level (50000).
 
 
-\section contexts Logging Contexts
-
-The logging context is maintained via a global stack onto which names can be pushed and popped using the lsst.log macros `LOG_PUSHCTX(name)` and `LOG_POPCTX()` within C++ or the `lsst.log` functions `pushContext(name)` and {{{popContext()}}} within Python. The default logger name is dynamically constructed each time a name is pushed onto or popped from the logging context. For example, within the Qserv demo, the following code can be found within `app.py`:
-
-    lsst.log.initLog("/u1/bchick/sandbox2/modules/etc/Log4cxxConfig.xml")
-    lsst.log.pushContext("czar")
-    [...]
-    lsst.log.debug("This is a debug statement!")
-
-The debugging statement is sent to the default logger, which in this case is ''czar''. Later, within the {{{submitQuery3()}}} function of {{{control/dispatcher.cc}}}, we have:
-
-    LOG_PUSHCTX("control");
-
-At this point, any logging statements that do not specify a logger name will be associated with a default logger of ''czar.control''. This mechanism allows dynamic hierarchical logging without hardcoding full logger names in order to accommodate better code re-use. Logging could then be configured, for example, so that the ''czar.control'' context is redirected or copied to a special file with a unique logging level.
-
-To pop a name from the logging context, invoke the {{{lsst.log.popContext()}}} function within Python or the {{{LOG_POPCTX()}}} macro within C++.
-
-The context determines the default logger, which is used whenever a logger is not explicitly indicated or an empty string is provided as the logger name.
-
-To summarize, within C++, we have the following macros:
-- `LOG_PUSHCTX(name)` Push '''`name`''' onto the global context stack such that the default logger name is appended with ".'''`name`'''".
-- `LOG_POPCTX()` Pop the last name `C` off of the global context stack such that a previous default logger name "`A`.`B`.`C`" is now "`A`.`B`".
-- `LOG_DEFAULT_NAME()` Returns the default logger name.
-
-And in Python, the following functions are available in the `lsst.log` module:
-- `pushContext(name)` Push '''`name`''' onto the global context stack such that the default logger name is appended with ".'''`name`'''".
-- `popContext()` Pop the last name `C` off of the global context stack such that a previous default logger name "`A`.`B`.`C`" is now "`A`.`B`".
-- `getDefaultLoggerName()` Returns the default logger name.
-
-
-\section ctxObj Context Objects
-
-Requiring that developers properly pop each context name is error prone. Therefore, we also provide logging context objects in both C++ and Python, which automatically pop names when the object is discarded.
-
-In C++, the context object will pop the provided name in its destructor. Contexts can therefore be managed as follows:
-
-    {
-        LOG_CTX context("demo");
-        LOG_INFO("Info statement within demo context.");
-    }
-    LOG_INFO("Info statement outside demo context.");
-
-In this example, if the context were initially "nameOne.nameTwo", the first logging statement would be sent to the logger named "nameOne.nameTwo.demo" and the second logging statement would be sent to the logger named "nameOne.nameTwo".
-
-The LogContext class defined in the Python layer is compatible with Python's `with` statement, and therefore, the above example can be implemented in Python as follows:
-
-    with LogContext(name="demo") as context:
-        lsst.log.info("Info statement within demo context.")
-    lsst.log.info("Info statement outside demo context.")
-
-
 \section flDebugging Fine-level Debugging Example
 
 The following is a simple recipe for emulating additional debugging levels using the above API within Python. Analogous code can be readily written in C++ using the corresponding macros.
@@ -350,7 +298,7 @@ The following is a simple recipe for emulating additional debugging levels using
         """
         Returns the logger name that corresponds to fine-level debugging number NUM.
         """
-        return '%s.debug%d' % (lsst.log.getDefaultLoggerName(), num)
+        return 'MyLogger.debug{}'.format(num)
 
     def debugAt(num, fmt, *args):
         """

--- a/examples/mp.py
+++ b/examples/mp.py
@@ -5,37 +5,38 @@ import multiprocessing as mp
 
 
 def main():
-    # Set component to "main" (from "root")
-    with log.LogContext("main"):
-        log.info("In main")
-        visits = [12345, 67890, 27182, 31415]
-        pool = mp.Pool(processes=2)
-        pool.map_async(a, visits)
-        pool.close()
-        pool.join()
-        b()
-        log.info("Leaving main")
+    # Use logger "main"
+    logger = log.getLogger("main")
+    logger.info("In main")
+    visits = [12345, 67890, 27182, 31415]
+    pool = mp.Pool(processes=2)
+    pool.map_async(a, [(visit, logger) for visit in visits])
+    pool.close()
+    pool.join()
+    b(logger)
+    log.info("Leaving main")
 
 
-def a(visit):
+def a(args):
+    visit, parentLogger = args
     # Set subcomponent to "a" (sets component to "main.a")
-    with log.LogContext("a"):
-        # Clean out any previous MDC for visit
-        log.MDCRemove("visit")
-        # All subsequent log messages will have visit id
-        log.MDC("visit", visit)
-        log.info("In a, %d", visit)
-        log.debug("Debug message in a")
-        b()
-        log.info("Leaving a")
+    logger = parentLogger.getChild("a")
+    # Clean out any previous MDC for visit
+    logger.MDCRemove("visit")
+    # All subsequent log messages will have visit id
+    logger.MDC("visit", str(visit))
+    logger.info("In a, %d", visit)
+    logger.debug("Debug message in a")
+    b(logger)
+    logger.info("Leaving a")
 
 
-def b():
+def b(parentLogger):
     # Set subcomponent to "b" (sets component to "main.a.b" or "main.b")
-    with log.LogContext("b"):
-        log.info("In b")
-        log.debug("Testing; logged only when called by a")
-        log.info("Leaving b")
+    logger = parentLogger.getChild("b")
+    logger.info("In b")
+    logger.debug("Testing; logged only when called by a")
+    logger.info("Leaving b")
 
 
 if __name__ == "__main__":

--- a/include/lsst/log/Log.h
+++ b/include/lsst/log/Log.h
@@ -83,32 +83,6 @@
 #define LOG_GET(logger) lsst::log::Log::getLogger(logger)
 
 /**
-  * @def LOG_PUSHCTX(name)
-  * Pushes name onto the global hierarchical default logger name.
-  * Note that we only allow simple non-dotted names to be used for
-  * context names, multi-level context name (e.g. "componen1.component2")
-  * will result in exception. Empty context names are disallowed as
-  * well, exception will be raised for empty name.
-  *
-  * @note Call to this macro is not thread-safe, moreover context is
-  * global and applies to all threads (which means you want to avoid
-  * using this in multi-threaded applications).
-  *
-  * @param name  String to push onto logging context.
-  * @throw std::invalid_argument raised for empty name or when name contains dot.
-  */
-#define LOG_PUSHCTX(name) lsst::log::Log::pushContext(name)
-
-/**
-  * @def LOG_POPCTX()
-  * Pops the last pushed name off the global hierarchical default logger
-  * name.
-  *
-  * @note Call to this macro is not thread-safe.
-  */
-#define LOG_POPCTX() lsst::log::Log::popContext()
-
-/**
   * @def LOG_MDC(key, value)
   * Places a KEY/VALUE pair in the Mapped Diagnostic Context (MDC) for the
   * current thread. The VALUE may then be included in log messages by using
@@ -710,7 +684,6 @@
 #define LOG_LVL_FATAL static_cast<int>(log4cxx::Level::FATAL_INT)
 
 #define LOG_LOGGER lsst::log::Log
-#define LOG_CTX lsst::log::LogContext
 
 namespace lsst {
 namespace log {
@@ -772,8 +745,6 @@ public:
     static Log getLogger(Log const& logger) { return logger; }
     static Log getLogger(std::string const& loggername);
 
-    static void pushContext(std::string const& name);
-    static void popContext();
     static void MDC(std::string const& key, std::string const& value);
     static void MDCRemove(std::string const& key);
     static int MDCRegisterInit(std::function<void()> function);
@@ -803,30 +774,6 @@ private:
 
     log4cxx::LoggerPtr _logger;
 };
-
-/** This class handles the default logger name of a logging context.
-  */
-class LogContext {
-public:
-    /** Create a logging context associated with a default logger name
-      * constructed by pushing \p name onto the pre-existing hierarchical default
-      * logger name. See comment to \c LOG_PUSHCTX about allowed names.
-      *
-      * @param name  String to push onto logging context.
-      */
-    explicit LogContext(std::string const& name) {
-        Log::pushContext(name);
-    }
-    ~LogContext() {
-        Log::popContext();
-    }
-
-private:
-    // cannot copy instances
-    LogContext(const LogContext&);
-    LogContext& operator=(const LogContext&);
-};
-
 
 /**
  * Function which returns LWP ID on platforms which support it.

--- a/include/lsst/log/Log.h
+++ b/include/lsst/log/Log.h
@@ -66,13 +66,6 @@
 #define LOG_CONFIG_PROP(string) lsst::log::Log::configure_prop(string)
 
 /**
-  * @def LOG_DEFAULT_NAME()
-  * Get the current default logger name. Returns empty string for root logger.
-  * @return String containing the default logger name.
-  */
-#define LOG_DEFAULT_NAME() lsst::log::Log::getDefaultLoggerName()
-
-/**
   * @def LOG_GET(logger)
   * Returns a Log object associated with logger.
   * @return Log object corresponding to logger.
@@ -732,7 +725,6 @@ public:
 
     /// Return default logger instance, same as default constructor.
     static Log getDefaultLogger() { return Log(); }
-    static std::string getDefaultLoggerName();
 
     static void configure();
     static void configure(std::string const& filename);

--- a/include/lsst/log/Log.h
+++ b/include/lsst/log/Log.h
@@ -75,6 +75,16 @@
 #define LOG_GET(logger) lsst::log::Log::getLogger(logger)
 
 /**
+  * @def LOG_GET_CHILD(logger)
+  * Returns a Log object associated with descendant of a logger.
+  * @return Log object corresponding to logger's descendant.
+  *
+  * @param logger  Either a logger name or a Log object.
+  * @param suffix  Suffix of a descendant.
+  */
+#define LOG_GET_CHILD(logger, suffix) lsst::log::Log::getLogger(logger).getChild(suffix)
+
+/**
   * @def LOG_MDC(key, value)
   * Places a KEY/VALUE pair in the Mapped Diagnostic Context (MDC) for the
   * current thread. The VALUE may then be included in log messages by using
@@ -722,6 +732,8 @@ public:
     void setLevel(int level);
     int getLevel() const;
     bool isEnabledFor(int level) const;
+
+    Log getChild(std::string const& suffix) const;
 
     /// Return default logger instance, same as default constructor.
     static Log getDefaultLogger() { return Log(); }

--- a/include/lsst/log/Log.h
+++ b/include/lsst/log/Log.h
@@ -38,7 +38,6 @@
 #include <sstream>
 #include <stdarg.h>
 #include <string>
-#include <vector>
 
 // Third-party headers
 #include <log4cxx/logger.h>
@@ -697,10 +696,7 @@ class Log {
 public:
 
     /***
-     *  Default constructor creates an instance of "current" logger.
-     *
-     *  Initially current logger is the same as root logger, but
-     *  current can be changed via pushContext()/popContext().
+     *  Default constructor creates an instance of root logger.
      */
     Log() : _logger(_defaultLogger()) { }
 
@@ -735,7 +731,7 @@ public:
     bool isEnabledFor(int level) const;
 
     /// Return default logger instance, same as default constructor.
-    static Log getDefaultLogger() { return Log(_defaultLogger()); }
+    static Log getDefaultLogger() { return Log(); }
     static std::string getDefaultLoggerName();
 
     static void configure();
@@ -759,16 +755,18 @@ public:
 private:
 
     /**
-     *  Returns default LOG4CXX logger.
+     *  Returns default LOG4CXX logger, which is the same as root logger.
      *
-     *  @param newDefault if non-zero then default is set to this value first.
+     *  This method is needed to ensure proper LOG4CXX initialization before
+     *  any code uses any logger instance.
      */
-    static log4cxx::LoggerPtr const& _defaultLogger(log4cxx::LoggerPtr const& newDefault=log4cxx::LoggerPtr());
+    static log4cxx::LoggerPtr const& _defaultLogger();
 
     /**
      *  Construct a Log using a LOG4CXX logger.
      *
-     *  The default constructor is called to ensure the default logger is initialized and LOG4CXX is configured.
+     *  The default constructor is called to ensure the default logger is
+     *  initialized and LOG4CXX is configured.
      */
     Log(log4cxx::LoggerPtr const& logger) : Log() { _logger = logger; }
 

--- a/python/lsst/log/log/log.cc
+++ b/python/lsst/log/log/log.cc
@@ -88,8 +88,6 @@ PYBIND11_MODULE(log, mod) {
     cls.def_static("configure_prop", Log::configure_prop);
     cls.def_static("getLogger", (Log(*)(Log const&))Log::getLogger);
     cls.def_static("getLogger", (Log(*)(std::string const&))Log::getLogger);
-    cls.def_static("pushContext", Log::pushContext);
-    cls.def_static("popContext", Log::popContext);
     cls.def_static("MDC", Log::MDC);
     cls.def_static("MDCRemove", Log::MDCRemove);
     cls.def_static("MDCRegisterInit", [](py::function func) {

--- a/python/lsst/log/log/log.cc
+++ b/python/lsst/log/log/log.cc
@@ -74,6 +74,7 @@ PYBIND11_MODULE(log, mod) {
     cls.def("setLevel", &Log::setLevel);
     cls.def("getLevel", &Log::getLevel);
     cls.def("isEnabledFor", &Log::isEnabledFor);
+    cls.def("getChild", &Log::getChild);
     cls.def("logMsg", [](Log& log, int level, std::string const& filename, std::string const& funcname,
                          unsigned int lineno, std::string const& msg) {
         log.logMsg(log4cxx::Level::toLevel(level),

--- a/python/lsst/log/log/log.cc
+++ b/python/lsst/log/log/log.cc
@@ -82,7 +82,6 @@ PYBIND11_MODULE(log, mod) {
     cls.def("lwpID", [](Log const& log) -> unsigned { return lsst::log::lwpID(); });
 
     cls.def_static("getDefaultLogger", Log::getDefaultLogger);
-    cls.def_static("getDefaultLoggerName", Log::getDefaultLoggerName);
     cls.def_static("configure", (void (*)())Log::configure);
     cls.def_static("configure", (void (*)(std::string const&))Log::configure);
     cls.def_static("configure_prop", Log::configure_prop);

--- a/python/lsst/log/log/logContinued.py
+++ b/python/lsst/log/log/logContinued.py
@@ -141,6 +141,10 @@ def getDefaultLogger():
     return Log.getDefaultLogger()
 
 
+def getLogger(loggername):
+    return Log.getLogger(loggername)
+
+
 def MDC(key, value):
     Log.MDC(key, str(value))
 

--- a/python/lsst/log/log/logContinued.py
+++ b/python/lsst/log/log/logContinued.py
@@ -137,8 +137,8 @@ def configure_prop(properties):
     Log.configure_prop(properties)
 
 
-def getDefaultLoggerName():
-    return Log.getDefaultLoggerName()
+def getDefaultLogger():
+    return Log.getDefaultLogger()
 
 
 def MDC(key, value):

--- a/python/lsst/log/log/logContinued.py
+++ b/python/lsst/log/log/logContinued.py
@@ -141,14 +141,6 @@ def getDefaultLoggerName():
     return Log.getDefaultLoggerName()
 
 
-def pushContext(name):
-    Log.pushContext(name)
-
-
-def popContext():
-    Log.popContext()
-
-
 def MDC(key, value):
     Log.MDC(key, str(value))
 
@@ -243,44 +235,6 @@ def usePythonLogging():
 
 def doNotUsePythonLogging():
     Log.doNotUsePythonLogging()
-
-
-class LogContext(object):
-    """Context manager for logging."""
-
-    def __init__(self, name=None, level=None):
-        self.name = name
-        self.level = level
-
-    def __enter__(self):
-        self.open()
-        return self
-
-    def __exit__(self, type, value, traceback):
-        self.close()
-
-    def __del__(self):
-        self.close()
-
-    def open(self):
-        if self.name is not None:
-            Log.pushContext(self.name)
-        if self.level is not None:
-            Log.getDefaultLogger().setLevel(self.level)
-
-    def close(self):
-        if self.name is not None:
-            Log.popContext()
-            self.name = None
-
-    def setLevel(self, level):
-        Log.getDefaultLogger().setLevel(level)
-
-    def getLevel(self):
-        return Log.getDefaultLogger().getLevel()
-
-    def isEnabledFor(self, level):
-        return Log.getDefaultLogger().isEnabledFor(level)
 
 
 class UsePythonLogging:

--- a/python/lsst/log/log/logContinued.py
+++ b/python/lsst/log/log/logContinued.py
@@ -125,6 +125,12 @@ class Log:
             else:
                 self.logMsg(level, filename, funcname, frame.f_lineno, msg)
 
+    def __reduce__(self):
+        """Implement pickle support.
+        """
+        args = (self.getName(), )
+        # method has to be module-level, not class method
+        return (getLogger, args)
 
 # Export static functions from Log class to module namespace
 

--- a/src/Log.cc
+++ b/src/Log.cc
@@ -259,47 +259,6 @@ Log Log::getLogger(std::string const& loggername) {
     }
 }
 
-/** Pushes NAME onto the global hierarchical default logger name.
-  *
-  * @param name  String to push onto logging context.
-  */
-void Log::pushContext(std::string const& name) {
-    // can't handle empty names
-    if (name.empty()) {
-        throw std::invalid_argument("lsst::log::Log::pushContext(): "
-                "empty context name is not allowed");
-    }
-    // we do not allow multi-level context (logger1.logger2)
-    if (name.find('.') != std::string::npos) {
-        throw std::invalid_argument("lsst::log::Log::pushContext(): "
-                "multi-level contexts are not allowed: " + name);
-    }
-
-    // Construct new default logger name
-    std::string newName = _defaultLogger()->getName();
-    if (newName == "root") {
-        newName = name;
-    } else {
-        newName += ".";
-        newName += name;
-    }
-    // Update defaultLogger
-    _defaultLogger(log4cxx::Logger::getLogger(newName));
-}
-
-/** Pops the last pushed name off the global hierarchical default logger
-  * name.
-  */
-void Log::popContext() {
-    // switch to parent logger, this assumes that loggers are not
-    // re-parented between calls to push and pop
-    log4cxx::LoggerPtr parent = _defaultLogger()->getParent();
-    // root logger does not have parent, stay at root instead
-    if (parent) {
-        _defaultLogger(parent);
-    }
-}
-
 /** Places a KEY/VALUE pair in the Mapped Diagnostic Context (MDC) for the
   * current thread. The VALUE may then be included in log messages by using
   * the following the `X` conversion character within a pattern layout as

--- a/src/Log.cc
+++ b/src/Log.cc
@@ -234,13 +234,6 @@ void Log::configure_prop(std::string const& properties) {
     log4cxx::PropertyConfigurator::configure(prop);
 }
 
-/** Get the current default logger name.
-  * @return String containing the default logger name.
-  */
-std::string Log::getDefaultLoggerName() {
-    return getDefaultLogger().getName();
-}
-
 /** Get the logger name associated with the Log object.
   * @return String containing the logger name.
   */

--- a/src/Log.cc
+++ b/src/Log.cc
@@ -335,6 +335,36 @@ bool Log::isEnabledFor(int level) const {
     }
 }
 
+/**
+  * Return a logger which is a descendant to this logger.
+  *
+  * If for example name of this logger is "main.task" and suffix is
+  * "subtask1.algorithm" then this method will return logger with the name
+  * "main.task.subtask1.algorithm". If this logger is root logger then
+  * suffix name is used for returned logger name. If suffix is empty
+  * then this instance is returned.
+  *
+  * @param suffix Suffix for tha name of returned logger, can include dot
+  *               (but not at leading position) and can be empty.
+  * @return Log instance.
+ */
+Log Log::getChild(std::string const& suffix) const {
+    // strip leading dots and spaces from suffix
+    auto pos = suffix.find_first_not_of(" .");
+    if (pos == std::string::npos) {
+        // empty, just return myself
+        return *this;
+    }
+    std::string name = getName();
+    if (name.empty()) {
+        name = suffix.substr(pos);
+    } else {
+        name += '.';
+        name += suffix.substr(pos);
+    }
+    return getLogger(name);
+}
+
 /** Method used by LOG_INFO and similar macros to process a log message
   * with variable arguments along with associated metadata.
   */

--- a/tests/testLog.cc
+++ b/tests/testLog.cc
@@ -187,63 +187,6 @@ BOOST_FIXTURE_TEST_CASE(basic_stream, LogFixture) {
           "INFO - Format 3 2.71828 foo c++\n");
 }
 
-
-BOOST_FIXTURE_TEST_CASE(context_stream, LogFixture) {
-    configure(LAYOUT_COMPONENT);
-
-    LOGS_TRACE("This is TRACE");
-    LOGS_INFO("This is INFO");
-    LOGS_DEBUG("This is DEBUG");
-    {
-        LOG_CTX context("componentX");
-        LOGS_TRACE("This is TRACE 1");
-        LOGS_INFO("This is INFO 1");
-        LOGS_DEBUG("This is DEBUG 1");
-    }
-    LOGS_TRACE("This is TRACE 2");
-    LOGS_INFO("This is INFO 2");
-    LOGS_DEBUG("This is DEBUG 2");
-    {
-        LOG_CTX context("compY");
-        LOGS_TRACE("This is TRACE 3");
-        LOGS_INFO("This is INFO 3");
-        LOGS_DEBUG("This is DEBUG 3");
-        LOG_SET_LVL(LOG_DEFAULT_NAME(), LOG_LVL_INFO);
-        BOOST_CHECK_EQUAL(LOG_GET_LVL(LOG_DEFAULT_NAME()),
-                          LOG_LVL_INFO);
-        LOGS_TRACE("This is TRACE 3a");
-        LOGS_INFO("This is INFO 3a");
-        LOGS_DEBUG("This is DEBUG 3a");
-        {
-            LOG_CTX context("subcompZ");
-            LOG_SET_LVL(LOG_DEFAULT_NAME(), LOG_LVL_TRACE);
-            BOOST_CHECK_EQUAL(LOG_GET_LVL(LOG_DEFAULT_NAME()),
-                              LOG_LVL_TRACE);
-            LOGS_TRACE("This is TRACE 4");
-            LOGS_INFO("This is INFO 4");
-            LOGS_DEBUG("This is DEBUG 4");
-        }
-        LOGS_TRACE("This is TRACE 5");
-        LOGS_INFO("This is INFO 5");
-        LOGS_DEBUG("This is DEBUG 5");
-    }
-
-    check("INFO  root - This is INFO\n"
-          "DEBUG root - This is DEBUG\n"
-          "INFO  componentX - This is INFO 1\n"
-          "DEBUG componentX - This is DEBUG 1\n"
-          "INFO  root - This is INFO 2\n"
-          "DEBUG root - This is DEBUG 2\n"
-          "INFO  compY - This is INFO 3\n"
-          "DEBUG compY - This is DEBUG 3\n"
-          "INFO  compY - This is INFO 3a\n"
-          "TRACE compY.subcompZ - This is TRACE 4\n"
-          "INFO  compY.subcompZ - This is INFO 4\n"
-          "DEBUG compY.subcompZ - This is DEBUG 4\n"
-          "INFO  compY - This is INFO 5\n");
-}
-
-
 BOOST_FIXTURE_TEST_CASE(pattern_stream, LogFixture) {
 
     std::string expected_msg =
@@ -251,10 +194,10 @@ BOOST_FIXTURE_TEST_CASE(pattern_stream, LogFixture) {
           "DEBUG root pattern_stream test_method (tests/testLog.cc:%2%) tests/testLog.cc(%2%) - This is DEBUG - {}\n"
           "INFO  root pattern_stream test_method (tests/testLog.cc:%3%) tests/testLog.cc(%3%) - This is INFO 2 - {{x,3}{y,foo}}\n"
           "DEBUG root pattern_stream test_method (tests/testLog.cc:%4%) tests/testLog.cc(%4%) - This is DEBUG 2 - {{x,3}{y,foo}}\n"
-          "INFO  component pattern_stream test_method (tests/testLog.cc:%5%) tests/testLog.cc(%5%) - This is INFO 3 - {{x,3}{y,foo}}\n"
-          "DEBUG component pattern_stream test_method (tests/testLog.cc:%6%) tests/testLog.cc(%6%) - This is DEBUG 3 - {{x,3}{y,foo}}\n"
-          "INFO  component pattern_stream test_method (tests/testLog.cc:%7%) tests/testLog.cc(%7%) - This is INFO 4 - {{y,foo}}\n"
-          "DEBUG component pattern_stream test_method (tests/testLog.cc:%8%) tests/testLog.cc(%8%) - This is DEBUG 4 - {{y,foo}}\n"
+          "INFO  root pattern_stream test_method (tests/testLog.cc:%5%) tests/testLog.cc(%5%) - This is INFO 3 - {{x,3}{y,foo}}\n"
+          "DEBUG root pattern_stream test_method (tests/testLog.cc:%6%) tests/testLog.cc(%6%) - This is DEBUG 3 - {{x,3}{y,foo}}\n"
+          "INFO  root pattern_stream test_method (tests/testLog.cc:%7%) tests/testLog.cc(%7%) - This is INFO 4 - {{y,foo}}\n"
+          "DEBUG root pattern_stream test_method (tests/testLog.cc:%8%) tests/testLog.cc(%8%) - This is DEBUG 4 - {{y,foo}}\n"
           "INFO  root pattern_stream test_method (tests/testLog.cc:%9%) tests/testLog.cc(%9%) - This is INFO 5 - {{y,foo}}\n"
           "DEBUG root pattern_stream test_method (tests/testLog.cc:%10%) tests/testLog.cc(%10%) - This is DEBUG 5 - {{y,foo}}\n";
     std::vector<std::string> args;
@@ -274,7 +217,6 @@ BOOST_FIXTURE_TEST_CASE(pattern_stream, LogFixture) {
     LOG_MDC_REMOVE("z");
 
     {
-        LOG_CTX context("component");
         LOGS_TRACE("This is TRACE 3");
         LOGS_INFO_LINENO("This is INFO 3", args);
         LOGS_DEBUG_LINENO("This is DEBUG 3", args);
@@ -341,51 +283,6 @@ BOOST_FIXTURE_TEST_CASE(MDCPutPid, LogFixture) {
         exit(0);
     }
 
-}
-
-BOOST_FIXTURE_TEST_CASE(context1_stream, LogFixture) {
-    configure(LAYOUT_COMPONENT);
-
-    LOGS_INFO("default logger name is " << LOG_DEFAULT_NAME());
-    LOG_PUSHCTX("component1");
-    LOGS_INFO("default logger name is " << LOG_DEFAULT_NAME());
-    LOG_PUSHCTX("component2");
-    LOGS_INFO("default logger name is " << LOG_DEFAULT_NAME());
-    LOG_POPCTX();
-    LOGS_INFO("default logger name is " << LOG_DEFAULT_NAME());
-    LOG_POPCTX();
-
-    {
-        LOG_CTX context1("component3");
-        LOGS_INFO("default logger name is " << LOG_DEFAULT_NAME());
-        {
-            LOG_CTX context1("component4");
-            LOGS_INFO("default logger name is " << LOG_DEFAULT_NAME());
-        }
-        LOGS_INFO("default logger name is " << LOG_DEFAULT_NAME());
-    }
-    LOGS_INFO("default logger name is " << LOG_DEFAULT_NAME());
-
-    // unmatched POP will leave us at root logger
-    LOG_POPCTX();
-    LOGS_INFO("default logger name is " << LOG_DEFAULT_NAME());
-
-    check("INFO  root - default logger name is \n"
-          "INFO  component1 - default logger name is component1\n"
-          "INFO  component1.component2 - default logger name is component1.component2\n"
-          "INFO  component1 - default logger name is component1\n"
-          "INFO  component3 - default logger name is component3\n"
-          "INFO  component3.component4 - default logger name is component3.component4\n"
-          "INFO  component3 - default logger name is component3\n"
-          "INFO  root - default logger name is \n"
-          "INFO  root - default logger name is \n");
-}
-
-BOOST_FIXTURE_TEST_CASE(context_exc, LogFixture) {
-    configure(LAYOUT_COMPONENT);
-
-    // multi-level context will result in exception
-    BOOST_CHECK_THROW(LOG_PUSHCTX("x.y"), std::invalid_argument);
 }
 
 BOOST_FIXTURE_TEST_CASE(dm_1186, LogFixture) {

--- a/tests/testLog.cc
+++ b/tests/testLog.cc
@@ -187,6 +187,19 @@ BOOST_FIXTURE_TEST_CASE(basic_stream, LogFixture) {
           "INFO - Format 3 2.71828 foo c++\n");
 }
 
+BOOST_AUTO_TEST_CASE(child_logger) {
+    auto log1 = LOG_GET_CHILD("", "child1");
+    BOOST_TEST(log1.getName() == "child1");
+    auto log2 = LOG_GET_CHILD(log1, "child2");
+    BOOST_TEST(log2.getName() == "child1.child2");
+    auto log2a = LOG_GET_CHILD(log1, ".child2");
+    BOOST_TEST(log2a.getName() == "child1.child2");
+    auto log3 = LOG_GET_CHILD(log2, " .. child3");
+    BOOST_TEST(log3.getName() == "child1.child2.child3");
+    auto log3a = LOG_GET_CHILD(log1, "child2.child3");
+    BOOST_TEST(log3a.getName() == "child1.child2.child3");
+}
+
 BOOST_FIXTURE_TEST_CASE(pattern_stream, LogFixture) {
 
     std::string expected_msg =

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -586,6 +586,21 @@ INFO message: lsst.log root logger, PythonLogging""")
             self.assertEqual(log.LevelTranslator.lsstLog2logging(logLevel), loggingLevel)
             self.assertEqual(log.LevelTranslator.logging2lsstLog(loggingLevel), logLevel)
 
+    def testChildLogger(self):
+        """Check the getChild logger method."""
+        logger = log.getDefaultLogger()
+        self.assertEqual(logger.getName(), "")
+        logger1 = logger.getChild("child1")
+        self.assertEqual(logger1.getName(), "child1")
+        logger2 = logger1.getChild("child2")
+        self.assertEqual(logger2.getName(), "child1.child2")
+        logger2a = logger1.getChild(".child2")
+        self.assertEqual(logger2a.getName(), "child1.child2")
+        logger3 = logger2.getChild(" .. child3")
+        self.assertEqual(logger3.getName(), "child1.child2.child3")
+        logger3a = logger1.getChild("child2.child3")
+        self.assertEqual(logger3a.getName(), "child1.child2.child3")
+
 
 if __name__ == "__main__":
     unittest.main()

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -85,7 +85,7 @@ class TestLog(unittest.TestCase):
 
     def testDefaultLogger(self):
         """Check the default root logger name."""
-        self.assertEqual(log.getDefaultLoggerName(), "")
+        self.assertEqual(log.getDefaultLogger().getName(), "")
 
     def testBasic(self):
         """
@@ -95,7 +95,7 @@ class TestLog(unittest.TestCase):
         """
         with TestLog.StdoutCapture(self.outputFilename):
             log.configure()
-            log.log(log.getDefaultLoggerName(), log.INFO, "This is INFO")
+            log.log(log.getDefaultLogger(), log.INFO, "This is INFO")
             log.info(u"This is unicode INFO")
             log.trace("This is TRACE")
             log.debug("This is DEBUG")
@@ -121,7 +121,7 @@ root WARN: Format 3 2.71828 foo
         """
         with TestLog.StdoutCapture(self.outputFilename):
             log.configure()
-            log.logf(log.getDefaultLoggerName(), log.INFO,
+            log.logf(log.getDefaultLogger(), log.INFO,
                      "This is {{INFO}} Item 1: {item[1]}",
                      item=["a", "b", "c"])
             log.infof(u"This is {unicode} INFO")

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -141,56 +141,6 @@ root FATAL: This is FATAL 3 out of 4 times for LSST
 root WARN: Format 3 2.71828 foo
 """)
 
-    def testContext(self):
-        """Test the log context/component stack."""
-        with TestLog.StdoutCapture(self.outputFilename):
-            log.configure()
-            log.setLevel('', log.DEBUG)
-            log.trace("This is TRACE")
-            log.info("This is INFO")
-            log.debug("This is DEBUG")
-            with log.LogContext("component"):
-                log.trace("This is TRACE")
-                log.info("This is INFO")
-                log.debug("This is DEBUG")
-            log.trace("This is TRACE 2")
-            log.info("This is INFO 2")
-            log.debug("This is DEBUG 2")
-            with log.LogContext("comp") as ctx:
-                log.trace("This is TRACE 3")
-                log.info("This is INFO 3")
-                log.debug("This is DEBUG 3")
-                ctx.setLevel(log.INFO)
-                self.assertEqual(ctx.getLevel(), log.INFO)
-                self.assertTrue(ctx.isEnabledFor(log.INFO))
-                log.trace("This is TRACE 3a")
-                log.info("This is INFO 3a")
-                log.debug("This is DEBUG 3a")
-                with log.LogContext("subcomp", log.TRACE) as ctx2:
-                    self.assertEqual(ctx2.getLevel(), log.TRACE)
-                    log.trace("This is TRACE 4")
-                    log.info("This is INFO 4")
-                    log.debug("This is DEBUG 4")
-                log.trace("This is TRACE 5")
-                log.info("This is INFO 5")
-                log.debug("This is DEBUG 5")
-
-        self.check("""
-root INFO: This is INFO
-root DEBUG: This is DEBUG
-component INFO: This is INFO
-component DEBUG: This is DEBUG
-root INFO: This is INFO 2
-root DEBUG: This is DEBUG 2
-comp INFO: This is INFO 3
-comp DEBUG: This is DEBUG 3
-comp INFO: This is INFO 3a
-comp.subcomp TRACE: This is TRACE 4
-comp.subcomp INFO: This is INFO 4
-comp.subcomp DEBUG: This is DEBUG 4
-comp INFO: This is INFO 5
-""")
-
     def testPattern(self):
         """
         Test a complex pattern for log messages, including Mapped
@@ -216,14 +166,13 @@ log4j.appender.CA.layout.ConversionPattern=%-5p %c %C %M (%F:%L) %l - %m - %X%n
             log.debug("This is DEBUG 2")
             log.MDCRemove("z")
 
-            with log.LogContext("component"):
-                log.trace("This is TRACE 3")
-                log.info("This is INFO 3")
-                log.debug("This is DEBUG 3")
-                log.MDCRemove("x")
-                log.trace("This is TRACE 4")
-                log.info("This is INFO 4")
-                log.debug("This is DEBUG 4")
+            log.trace("This is TRACE 3")
+            log.info("This is INFO 3")
+            log.debug("This is DEBUG 3")
+            log.MDCRemove("x")
+            log.trace("This is TRACE 4")
+            log.info("This is INFO 4")
+            log.debug("This is DEBUG 4")
 
             log.trace("This is TRACE 5")
             log.info("This is INFO 5")
@@ -237,13 +186,13 @@ INFO  root  testPattern (test_log.py:{0[0]}) test_log.py({0[0]}) - This is INFO 
 DEBUG root  testPattern (test_log.py:{0[1]}) test_log.py({0[1]}) - This is DEBUG - {{}}
 INFO  root  testPattern (test_log.py:{0[2]}) test_log.py({0[2]}) - This is INFO 2 - {{{{x,3}}{{y,foo}}{{z,<class '{1}.TestLog'>}}}}
 DEBUG root  testPattern (test_log.py:{0[3]}) test_log.py({0[3]}) - This is DEBUG 2 - {{{{x,3}}{{y,foo}}{{z,<class '{1}.TestLog'>}}}}
-INFO  component  testPattern (test_log.py:{0[4]}) test_log.py({0[4]}) - This is INFO 3 - {{{{x,3}}{{y,foo}}}}
-DEBUG component  testPattern (test_log.py:{0[5]}) test_log.py({0[5]}) - This is DEBUG 3 - {{{{x,3}}{{y,foo}}}}
-INFO  component  testPattern (test_log.py:{0[6]}) test_log.py({0[6]}) - This is INFO 4 - {{{{y,foo}}}}
-DEBUG component  testPattern (test_log.py:{0[7]}) test_log.py({0[7]}) - This is DEBUG 4 - {{{{y,foo}}}}
+INFO  root  testPattern (test_log.py:{0[4]}) test_log.py({0[4]}) - This is INFO 3 - {{{{x,3}}{{y,foo}}}}
+DEBUG root  testPattern (test_log.py:{0[5]}) test_log.py({0[5]}) - This is DEBUG 3 - {{{{x,3}}{{y,foo}}}}
+INFO  root  testPattern (test_log.py:{0[6]}) test_log.py({0[6]}) - This is INFO 4 - {{{{y,foo}}}}
+DEBUG root  testPattern (test_log.py:{0[7]}) test_log.py({0[7]}) - This is DEBUG 4 - {{{{y,foo}}}}
 INFO  root  testPattern (test_log.py:{0[8]}) test_log.py({0[8]}) - This is INFO 5 - {{{{y,foo}}}}
 DEBUG root  testPattern (test_log.py:{0[9]}) test_log.py({0[9]}) - This is DEBUG 5 - {{{{y,foo}}}}
-""".format([x + 207 for x in (0, 1, 8, 9, 14, 15, 18, 19, 22, 23)], __name__))  # noqa E501 line too long
+""".format([x + 157 for x in (0, 1, 8, 9, 13, 14, 17, 18, 21, 22)], __name__))  # noqa E501 line too long
 
     def testMDCPutPid(self):
         """
@@ -275,7 +224,7 @@ log4j.appender.CA.layout.ConversionPattern=%-5p PID:%X{{PID}} %c %C %M (%F:%L) %
 
             with TestLog.StdoutCapture(self.outputFilename):
                 log.info(msg)
-                line = 277
+                line = 226  # line number for previous line
         finally:
             log.MDCRemove("PID")
 
@@ -297,10 +246,9 @@ log4j.appender.FA.file={0}
 log4j.appender.FA.layout=SimpleLayout
 """)
         log.MDC("x", 3)
-        with log.LogContext("component"):
-            log.trace("This is TRACE")
-            log.info("This is INFO")
-            log.debug("This is DEBUG")
+        log.trace("This is TRACE")
+        log.info("This is INFO")
+        log.debug("This is DEBUG")
         log.MDCRemove("x")
 
         self.check("""


### PR DESCRIPTION
In addition there are few small improvements:
- initialization/configuration step is made thread safe, and less confusing
- Python `Log` class now supports `pickle` so it can work with `multiprocess`
- added `Log.getChild` method to make it look more like Pylon `logging` logger, this is also a better replacement for hierarchical "context" management if someone needs that
