### PR TITLE
DM-21043: Qserv log diet: use named context for query ID

### DIFF
--- a/doc/mainpage.dox
+++ b/doc/mainpage.dox
@@ -357,12 +357,12 @@ or alternatively using `%%X` format code without additional key to display full 
     "%d [%t] %-5p %c{2} %m%n MDC=%X"
 
 In C++, the following MDC macros are available:
-- `LOG_MDC(key, value)` Map the value '''`value`''' to the global key '''`key`''' such that it may be included in subsequent log messages by including the directive `%X{`'''`key`'''`}` in the formatting string of an associated appender.
+- `LOG_MDC(key, value)` Map the value '''`value`''' to the global key '''`key`''' such that it may be included in subsequent log messages by including the directive `%%X{`'''`key`'''`}` in the formatting string of an associated appender.
 - `LOG_MDC_REMOVE(key)` Delete the existing value from the global map that is associated with '''`key`'''.
 - `LOG_MDC_SCOPE(key, value)` Adds key/value to MDC and restores previous value when execution leaves the scope. Typically used at the beggining of the function if one needs to define MDC key/value for the whole duration of the function.
 
 In Python, the `lsst.log` module provides the following MDC functions:
-- `MDC(key, value)` Map the value '''`value`''' to the global key '''`key`''' such that it may be included in subsequent log messages by including the directive `%X{`'''`key`'''`}` in the formatting string of an associated appender. Note that `value` is converted to a string by Python before it is stored in the MDC.
+- `MDC(key, value)` Map the value '''`value`''' to the global key '''`key`''' such that it may be included in subsequent log messages by including the directive `%%X{`'''`key`'''`}` in the formatting string of an associated appender. Note that `value` is converted to a string by Python before it is stored in the MDC.
 - `MDCRemove(key)` Delete the existing value from the global map that is associated with '''`key`'''.
 
 \subsection PID Display PID in the LSST logs
@@ -393,7 +393,7 @@ This has to be done after fork() and corresponding formatting code needs to be a
 
 \subsection TID Display thread ID
 
-The conversion pattern in log4cxx has special conversion code (`%t`) to render "thread ID", the rendered value is a pointer to `thread_t` object (on POSIX systems) and is rendered as a long string of hexadecimal digits which makes it difficult to read for non-hardcore programmers. `lsst.log` provides more human-friendly way to print thread-identifying information. Special function `lsst::log::lwpID()` returns light-weight process ID (LWP) on the plaftorms that support this feature and small incremental integer number on other platforms. Using this function one can add LWP to MDC and configure output format to include this special MDC key:
+The conversion pattern in log4cxx has special conversion code (`%%t`) to render "thread ID", the rendered value is a pointer to `thread_t` object (on POSIX systems) and is rendered as a long string of hexadecimal digits which makes it difficult to read for non-hardcore programmers. `lsst.log` provides more human-friendly way to print thread-identifying information. Special function `lsst::log::lwpID()` returns light-weight process ID (LWP) on the plaftorms that support this feature and small incremental integer number on other platforms. Using this function one can add LWP to MDC and configure output format to include this special MDC key:
 
 In C++:
 

--- a/doc/mainpage.dox
+++ b/doc/mainpage.dox
@@ -359,6 +359,7 @@ or alternatively using `%%X` format code without additional key to display full 
 In C++, the following MDC macros are available:
 - `LOG_MDC(key, value)` Map the value '''`value`''' to the global key '''`key`''' such that it may be included in subsequent log messages by including the directive `%X{`'''`key`'''`}` in the formatting string of an associated appender.
 - `LOG_MDC_REMOVE(key)` Delete the existing value from the global map that is associated with '''`key`'''.
+- `LOG_MDC_SCOPE(key, value)` Adds key/value to MDC and restores previous value when execution leaves the scope. Typically used at the beggining of the function if one needs to define MDC key/value for the whole duration of the function.
 
 In Python, the `lsst.log` module provides the following MDC functions:
 - `MDC(key, value)` Map the value '''`value`''' to the global key '''`key`''' such that it may be included in subsequent log messages by including the directive `%X{`'''`key`'''`}` in the formatting string of an associated appender. Note that `value` is converted to a string by Python before it is stored in the MDC.

--- a/src/Log.cc
+++ b/src/Log.cc
@@ -269,13 +269,16 @@ Log Log::getLogger(std::string const& loggername) {
   *
   * @param key    Unique key.
   * @param value  String value.
+  * @return Previous value for the key in the MDC.
   */
-void Log::MDC(std::string const& key, std::string const& value) {
+std::string Log::MDC(std::string const& key, std::string const& value) {
     // put() does not remove existing mapping, to make it less confusing
     // for clients which expect that MDC() always overwrites existing mapping
     // we explicitly remove it first if it exists.
+    std::string const oldValue = log4cxx::MDC::get(key);
     log4cxx::MDC::remove(key);
     log4cxx::MDC::put(key, value);
+    return oldValue;
 }
 
 /** Remove the value associated with KEY within the MDC.

--- a/tests/testLog.cc
+++ b/tests/testLog.cc
@@ -212,7 +212,11 @@ BOOST_FIXTURE_TEST_CASE(pattern_stream, LogFixture) {
           "INFO  root pattern_stream test_method (tests/testLog.cc:%7%) tests/testLog.cc(%7%) - This is INFO 4 - {{y,foo}}\n"
           "DEBUG root pattern_stream test_method (tests/testLog.cc:%8%) tests/testLog.cc(%8%) - This is DEBUG 4 - {{y,foo}}\n"
           "INFO  root pattern_stream test_method (tests/testLog.cc:%9%) tests/testLog.cc(%9%) - This is INFO 5 - {{y,foo}}\n"
-          "DEBUG root pattern_stream test_method (tests/testLog.cc:%10%) tests/testLog.cc(%10%) - This is DEBUG 5 - {{y,foo}}\n";
+          "DEBUG root pattern_stream test_method (tests/testLog.cc:%10%) tests/testLog.cc(%10%) - This is DEBUG 5 - {{y,foo}}\n"
+          "INFO  root pattern_stream test_method (tests/testLog.cc:%11%) tests/testLog.cc(%11%) - This is INFO 6 - {{y,foo}{z,zzz}}\n"
+          "INFO  root pattern_stream test_method (tests/testLog.cc:%12%) tests/testLog.cc(%12%) - This is INFO 7 - {{y,foo}}\n"
+          "INFO  root pattern_stream test_method (tests/testLog.cc:%13%) tests/testLog.cc(%13%) - This is INFO 8 - {{q,qqq}{y,foo}}\n"
+          "INFO  root pattern_stream test_method (tests/testLog.cc:%14%) tests/testLog.cc(%14%) - This is INFO 9 - {{y,foo}}\n";
     std::vector<std::string> args;
 
     configure(LAYOUT_PATTERN);
@@ -241,6 +245,20 @@ BOOST_FIXTURE_TEST_CASE(pattern_stream, LogFixture) {
     LOGS_TRACE("This is TRACE 5");
     LOGS_INFO_LINENO("This is INFO 5", args);
     LOGS_DEBUG_LINENO("This is DEBUG 5", args);
+
+    {
+        LOG_MDC_SCOPE("z", "zzz");
+        LOGS_INFO_LINENO("This is INFO 6", args);
+    }
+    LOGS_INFO_LINENO("This is INFO 7", args);
+
+    {
+        // test move semantics
+        auto func = []() { return lsst::log::LogMDCScope("q", "qqq"); };
+        auto mdc_scope = func();
+        LOGS_INFO_LINENO("This is INFO 8", args);
+    }
+    LOGS_INFO_LINENO("This is INFO 9", args);
 
     LOG_MDC_REMOVE("y");
 


### PR DESCRIPTION
Implement scope guard for logging MDC.

This small addition to log package is needed to support scope-based MDC control in qserv. It could be useful for other clients too.