### PR TITLE
DM-30015: Update Sphinx conf.py for documenteer 0.6

### DIFF
--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -30,7 +30,7 @@ jobs:
             pybind11[global] \
             pytest \
             pytest-flake8 \
-            git+https://github.com/lsst/utils@master#egg=lsst_utils
+            git+https://github.com/lsst/utils@main#egg=lsst_utils
 
       - name: CMake configure
         run: |

--- a/README.rst
+++ b/README.rst
@@ -1,0 +1,8 @@
+###
+log
+###
+
+``log`` is a package in the `LSST Science Pipelines <https://pipelines.lsst.io>`_.
+
+The ``lsst.log`` module provides logging for C++ and Python.
+Documentation is available at https://pipelines.lsst.io/modules/lsst.log/index.html.

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -1,6 +1,7 @@
 """Sphinx configuration file for an LSST stack package.
-
 This configuration only affects single-package Sphinx documentation builds.
+For more information, see:
+https://developer.lsst.io/stack/building-single-package-docs.html
 """
 
 from documenteer.conf.pipelinespkg import *  # noqa: F403, import *

--- a/setup.cfg
+++ b/setup.cfg
@@ -1,7 +1,12 @@
 [flake8]
 max-line-length = 110
 ignore = E133, E226, E228, N802, N803, N806, W503
-exclude = __init__.py
+exclude =
+  bin,
+  doc/conf.py,
+  **/*/__init__.py,
+  **/*/version.py,
+  tests/.tests
 
 [tool:pytest]
 addopts = --flake8


### PR DESCRIPTION
Updates based on the latest updates in the package template (https://github.com/lsst/templates/tree/master/project_templates/stack_package)

- Add a basic README
- Update doc/conf.py for the documenteer 0.6 Sphinx configuration API