### PR TITLE
DM-37534: Remove other f-string variants

### DIFF
--- a/doc/mainpage.dox
+++ b/doc/mainpage.dox
@@ -136,15 +136,6 @@ In Python, the following logging functions are available in the `lsst.log` modul
 - `error(fmt, *args)` Log a message of level `ERROR` with format string '''`fmt`''' and corresponding arguments '''`*args`''' to the default logger.
 - `fatal(fmt, *args)` Log a message of level `FATAL` with format string '''`fmt`''' and corresponding arguments '''`*args`''' to the default logger.
 
-Additionally, Python has variants of the above functions, with a trailing `f` in the name, supporting the Python string `format()` syntax. The use of `*args` and `**kwargs` is recommended over the use of calling the `format()` method on the string directly, to avoid unnecessarily formatting log messages that do not meet the level threshold.
-- `logf(loggername, level, fmt, *args, **kwargs)` Log a message of level '''`level`''' with format string '''`fmt`''' and variable arguments '''`*args`''' and '''`**kwargs`''' to the logger named '''`loggername`''' using format method syntax.
-- `tracef(fmt, *args, **kwargs)` Log a message of level `TRACE` with format string '''`fmt`''' and corresponding arguments '''`*args`''' and '''`**kwargs`''' to the default logger using format method syntax.
-- `debugf(fmt, *args, **kwargs)` Log a message of level `DEBUG` with format string '''`fmt`''' and corresponding arguments '''`*args`''' and '''`**kwargs`''' to the default logger using format method syntax.
-- `infof(fmt, *args, **kwargs)` Log a message of level `INFO` with format string '''`fmt`''' and corresponding arguments '''`*args`''' and '''`**kwargs`''' to the default logger using format method syntax.
-- `warnf(fmt, *args, **kwargs)` Log a message of level `WARN` with format string '''`fmt`''' and corresponding arguments '''`*args`''' and '''`**kwargs`''' to the default logger using format method syntax.
-- `errorf(fmt, *args, **kwargs)` Log a message of level `ERROR` with format string '''`fmt`''' and corresponding arguments '''`*args`''' and '''`**kwargs`''' to the default logger using format method syntax.
-- `fatalf(fmt, *args, **kwargs)` Log a message of level `FATAL` with format string '''`fmt`''' and corresponding arguments '''`*args`''' and '''`**kwargs`''' to the default logger using format method syntax.
-
 \section initialization Initialization
 
 The underlying log4cxx system can be initialized explicitly from either the C++ or Python layers or default-initialized.

--- a/python/lsst/log/log/logContinued.py
+++ b/python/lsst/log/log/logContinued.py
@@ -26,7 +26,7 @@ __all__ = ["TRACE", "DEBUG", "INFO", "WARN", "ERROR", "FATAL", "CRITICAL", "WARN
            "Log", "configure", "configure_prop", "configure_pylog_MDC", "getDefaultLogger",
            "getLogger", "MDC", "MDCDict", "MDCRemove", "MDCRegisterInit", "setLevel",
            "getLevel", "isEnabledFor", "log", "trace", "debug", "info", "warn", "warning",
-           "error", "fatal", "critical", "logf", "tracef", "debugf", "infof", "warnf", "errorf", "fatalf",
+           "error", "fatal", "critical",
            "lwpID", "usePythonLogging", "doNotUsePythonLogging", "UsePythonLogging",
            "LevelTranslator", "LogHandler", "getEffectiveLevel", "getLevelName"]
 
@@ -322,34 +322,6 @@ def fatal(fmt, *args):
 
 def critical(fmt, *args):
     fatal(fmt, *args)
-
-
-def logf(loggername, level, fmt, *args, **kwargs):
-    Log.getLogger(loggername)._log(level, True, fmt, *args, **kwargs)
-
-
-def tracef(fmt, *args, **kwargs):
-    Log.getDefaultLogger()._log(TRACE, True, fmt, *args, **kwargs)
-
-
-def debugf(fmt, *args, **kwargs):
-    Log.getDefaultLogger()._log(DEBUG, True, fmt, *args, **kwargs)
-
-
-def infof(fmt, *args, **kwargs):
-    Log.getDefaultLogger()._log(INFO, True, fmt, *args, **kwargs)
-
-
-def warnf(fmt, *args, **kwargs):
-    Log.getDefaultLogger()._log(WARN, True, fmt, *args, **kwargs)
-
-
-def errorf(fmt, *args, **kwargs):
-    Log.getDefaultLogger()._log(ERROR, True, fmt, *args, **kwargs)
-
-
-def fatalf(fmt, *args, **kwargs):
-    Log.getDefaultLogger()._log(FATAL, True, fmt, *args, **kwargs)
 
 
 def lwpID():

--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -114,35 +114,6 @@ root FATAL: This is CRITICAL
 root WARN: Format 3 2.71828 foo
 """)
 
-    def testBasicFormat(self):
-        """
-        Test basic log output with default configuration but using
-        the f variants.
-        Since the default threshold is INFO, the DEBUG or TRACE
-        message is not emitted.
-        """
-        with TestLog.StdoutCapture(self.outputFilename):
-            log.configure()
-            log.logf(log.getDefaultLogger(), log.INFO,
-                     "This is {{INFO}} Item 1: {item[1]}",
-                     item=["a", "b", "c"])
-            log.infof(u"This is {unicode} INFO")
-            log.tracef("This is TRACE")
-            log.debugf("This is DEBUG")
-            log.warnf("This is WARN {city}", city="Tucson")
-            log.errorf("This is ERROR {1}->{0}", 2, 1)
-            log.fatalf("This is FATAL {1} out of {0} times for {place}",
-                       4, 3, place="LSST")
-            log.warnf("Format {} {} {}", 3, 2.71828, "foo")
-        self.check("""
-root INFO: This is {INFO} Item 1: b
-root INFO: This is {unicode} INFO
-root WARN: This is WARN Tucson
-root ERROR: This is ERROR 1->2
-root FATAL: This is FATAL 3 out of 4 times for LSST
-root WARN: Format 3 2.71828 foo
-""")
-
     def testPattern(self):
         """
         Test a complex pattern for log messages, including Mapped
@@ -194,7 +165,7 @@ INFO  root  testPattern (test_log.py:{0[6]}) test_log.py({0[6]}) - This is INFO 
 DEBUG root  testPattern (test_log.py:{0[7]}) test_log.py({0[7]}) - This is DEBUG 4 - {{{{y,foo}}}}
 INFO  root  testPattern (test_log.py:{0[8]}) test_log.py({0[8]}) - This is INFO 5 - {{{{y,foo}}}}
 DEBUG root  testPattern (test_log.py:{0[9]}) test_log.py({0[9]}) - This is DEBUG 5 - {{{{y,foo}}}}
-""".format([x + 159 for x in (0, 1, 8, 9, 13, 14, 17, 18, 21, 22)], __name__))  # noqa E501 line too long
+""".format([x + 130 for x in (0, 1, 8, 9, 13, 14, 17, 18, 21, 22)], __name__))  # noqa E501 line too long
 
     def testMDCPutPid(self):
         """
@@ -226,7 +197,7 @@ log4j.appender.CA.layout.ConversionPattern=%-5p PID:%X{{PID}} %c %C %M (%F:%L) %
 
             with TestLog.StdoutCapture(self.outputFilename):
                 log.info(msg)
-                line = 228  # line number for previous line
+                line = 199  # line number for previous line
         finally:
             log.MDCRemove("PID")
 


### PR DESCRIPTION
Previously we only removed the f-string variants
that were explicitly marked deprecated but not the forwarders.