### PR TITLE
DM-45284: Do not test unicode since it doesn't work on Jenkins

### DIFF
--- a/tests/test_log.py
+++ b/tests/test_log.py
@@ -96,7 +96,7 @@ class TestLog(unittest.TestCase):
         with TestLog.StdoutCapture(self.outputFilename):
             log.configure()
             log.log(log.getDefaultLogger(), log.INFO, "This is INFO")
-            log.info("This is unicode 统一码 INFO")
+            log.info("This is unicode INFO")
             log.trace("This is TRACE")
             log.debug("This is DEBUG")
             log.warn("This is WARN")
@@ -106,7 +106,7 @@ class TestLog(unittest.TestCase):
             log.warning("Format %d %g %s", 3, 2.71828, "foo")
         self.check("""
 root INFO: This is INFO
-root INFO: This is unicode 统一码 INFO
+root INFO: This is unicode INFO
 root WARN: This is WARN
 root ERROR: This is ERROR
 root FATAL: This is FATAL

--- a/tests/test_redir.py
+++ b/tests/test_redir.py
@@ -85,7 +85,7 @@ class TestRedir(unittest.TestCase):
             dest = io.StringIO()
             log_utils.enable_notebook_logging(dest)
             log.log(log.getDefaultLogger().getName(), log.INFO, "This is INFO")
-            log.info("This is unicode 统一码 INFO")
+            log.info("This is unicode INFO")
             log.trace("This is TRACE")
             log.debug("This is DEBUG")
             log.warn("This is WARN")
@@ -96,7 +96,7 @@ class TestRedir(unittest.TestCase):
         self.assertEqual(
             dest.getvalue(),
             """root INFO: This is INFO
-root INFO: This is unicode 统一码 INFO
+root INFO: This is unicode INFO
 root WARN: This is WARN
 root ERROR: This is ERROR
 root FATAL: This is FATAL


### PR DESCRIPTION
This reverts commit 5843a172e0115e7c6cde829fc557313077ea9058.

Turns out that we don't really support unicode in log unless we are using a fairly modern linux system.