### PR TITLE
DM-51975: Update to `cmake` 3.12 or later

### DIFF
--- a/.github/workflows/cmake.yaml
+++ b/.github/workflows/cmake.yaml
@@ -46,6 +46,7 @@ jobs:
         run: |
           cmake \
             -DCMAKE_INSTALL_PREFIX=${{github.workspace}}/build/install \
+            -DPython_FIND_STRATEGY=LOCATION \
             -B ${{github.workspace}}/build
 
       - name: CMake build

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,4 +1,4 @@
-cmake_minimum_required(VERSION 3.1)
+cmake_minimum_required(VERSION 3.12)
 project(log)
 
 enable_testing()

--- a/python/lsst/log/CMakeLists.txt
+++ b/python/lsst/log/CMakeLists.txt
@@ -1,3 +1,4 @@
+find_package(Python COMPONENTS Development Interpreter)
 add_subdirectory(log)
 
 install(

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,4 @@
-find_package(Boost REQUIRED COMPONENTS
+find_package(Boost REQUIRED NO_MODULE COMPONENTS
     unit_test_framework REQUIRED
 )
 


### PR DESCRIPTION
Newer installations are starting to whinge about soon-to-be-deprecated cmake < 3.10. This upgrades minimal version from 3.1 to 3.10, and also updates to modern find python usage for pybind11.